### PR TITLE
Fix text in OpenGL (and add easy text example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Release/*
 *.exe
 ogltest
 rawdraw
+examples/fontsize
+examples/fontsize_ogl

--- a/CNFGFunctions.c
+++ b/CNFGFunctions.c
@@ -312,11 +312,14 @@ void CNFGTackSegment( short x1, short y1, short x2, short y2 )
 	{
 		glBegin( GL_POINTS );
 		glVertex2f( x1+.5, y1+.5 );
-		glEnd();		
+		glEnd();
 	}
 	else
 	{
-		glBegin( GL_LINES );
+		// GL_LINE misses the last pixel if the line is not continued
+		// due to the Diamond-exit rule so we use GL_LINE_LOOP which
+		// draws the line back and forth catching all the pixels.
+		glBegin( GL_LINE_LOOP );
 		glVertex2f( x1+.5, y1+.5 );
 		glVertex2f( x2+.5, y2+.5 );
 		glEnd();

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,25 @@
+all : fontsize fontsize_ogl
+
+#for X11 consider:             xorg-dev
+#for X11, you will need:       libx-dev
+#for full screen you'll need:  libxinerama-dev libxext-dev
+#for OGL You'll need:          mesa-common-dev libglu1-mesa-dev
+
+#-DRASTERIZER
+#  and
+#-CNFGOGL
+#  are incompatible.
+
+
+MINGW32:=/usr/bin/i686-w64-mingw32-
+
+fontsize : fontsize.c ../CNFGFunctions.c ../CNFGXDriver.c ../CNFG3D.c
+	gcc -o $@ $^ -lX11 -lm -lpthread -lXinerama -lXext -lGL -g -DRASTERIZER -Wall
+
+fontsize_ogl : fontsize.c ../CNFGFunctions.c ../CNFGXDriver.c ../CNFG3D.c
+	gcc -o $@ $^ -lX11 -lm -lpthread -lXinerama -lXext -lGL -g -lX11 -lXinerama -lGL -DCNFGOGL -Wall
+
+
+clean : 
+	rm -rf *.o *~ rawdraw.exe rawdraw ontop rawdraw_mac rawdraw_mac_soft rawdraw_mac_cg rawdraw_mac_ogl ogltest ogltest.exe rawdraw_egl fontsize fontsize_ogl
+

--- a/examples/fontsize.c
+++ b/examples/fontsize.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../CNFGFunctions.h"
+#include "../os_generic.h"
+#include "../CNFG3D.h"
+
+#if defined( CNFGOGL )
+#define TITLESTRING "Fontsize test with OpenGL"
+#elif defined( RASTERIZER )
+#define TITLESTRING "Fontsize test with Rasterizer"
+#else
+#define TITLESTRING "Fontsize test with Unknown"
+#endif
+
+void HandleKey( int keycode, int bDown )
+{
+	if( keycode == 65307 ) exit( 0 );
+	printf( "Key: %d -> %d\n", keycode, bDown );
+}
+
+void HandleButton( int x, int y, int button, int bDown )
+{
+	printf( "Button: %d,%d (%d) -> %d\n", x, y, button, bDown );
+}
+
+void HandleMotion( int x, int y, int mask )
+{
+//	printf( "Motion: %d,%d (%d)\n", x, y, mask );
+}
+
+void HandleDestroy()
+{
+	printf( "Destroying\n" );
+	exit(10);
+}
+
+int main()
+{
+
+	int i, x, y;
+	double ThisTime;
+	double LastFPSTime = OGGetAbsoluteTime();
+	double LastFrameTime = OGGetAbsoluteTime();
+	double SecToWait;
+
+	CNFGBGColor = 0x800000;
+	CNFGDialogColor = 0x444444;
+	CNFGSetup( TITLESTRING, 1220, 480 );
+
+
+
+	while ( 1 ) {
+		CNFGHandleInput();
+		CNFGClearFrame();
+		CNFGColor( 0xffffff );
+		for( i = 1; i < 5; i++ )
+		{
+			int c;
+			char tw[2] = { 0, 0 };
+			for( c = 0; c < 256; c++ )
+			{
+				tw[0] = c;
+
+				CNFGPenX = ( c % 16 ) * 16 + 5 + (i - 1) * 320;
+				CNFGPenY = ( c / 16 ) * 18 + 5;
+				CNFGDrawText( tw, i );
+			}
+		}
+		
+		CNFGPenX = 20;
+		CNFGPenY = 300;
+		for( i = 1; i < 7; i++) {
+			CNFGPenY += i * 6;
+			CNFGDrawText("A quick brown fox jumps over the lazy dog.", i);
+		}
+		CNFGSwapBuffers();
+		OGUSleep( (int)( 0.5 * 1000000 ) );
+	}
+}


### PR DESCRIPTION
I thought that I would start working on issue #13 by checking how the text looks in different sizes. I came up with this small example that might help newcomers in learning rawdraw. 

After the currently open PRs are decided, I can continue moving the other example files to this folder, if you agree that this would be a good idea.

The actual fix for #13 is just replacing GL_LINES with GL_LINE_LOOP. This draws the lines twice but I believe it is still the cleanest solution of all choices and I don't expect any problems with it.

